### PR TITLE
Graceful handling of newlines and support for Mappings and Sequences

### DIFF
--- a/pyprnt/prnt.py
+++ b/pyprnt/prnt.py
@@ -2,8 +2,10 @@ import sys
 from pyprnt.util import get_terminal_size, prnt_iteratable
 
 def prnt(*obj, enable=True, both=False, truncate=False,
-        depth=-1, width=get_terminal_size(), output=False,
+        depth=-1, width=None, output=False,
         sep=' ', end='\n', file=sys.stdout, flush=False):
+    width = width or get_terminal_size()
+
     try:
         if width < 20:
             raise ValueError('width should be bigger than 20')

--- a/pyprnt/prnt.py
+++ b/pyprnt/prnt.py
@@ -1,5 +1,6 @@
+from collections.abc import Mapping
 import sys
-from pyprnt.util import get_terminal_size, prnt_iteratable
+from pyprnt.util import get_terminal_size, prnt_iteratable, is_sequence_container
 
 def prnt(*obj, enable=True, both=False, truncate=False,
         depth=-1, width=None, output=False,
@@ -21,7 +22,7 @@ def prnt(*obj, enable=True, both=False, truncate=False,
         output_data = ""
 
         for i, o in enumerate(obj):
-            if enable and (type(o) == list or type(o) == dict):
+            if enable and (is_sequence_container(o) or isinstance(o, Mapping)):
                 if both:
                     print(o, sep=sep, file=file, flush=flush)
                     output_data = str(o) + "\n"
@@ -35,7 +36,7 @@ def prnt(*obj, enable=True, both=False, truncate=False,
                 else:
                     output_data = str(o) + temp_end
 
-                if i < len(obj)-1 and (type(obj[i+1]) == list or type(obj[i+1]) == dict):
+                if i < len(obj)-1 and (is_sequence_container(obj[i+1]) or isinstance(obj[i+1], Mapping)):
                     print()
         print(end=end)
         if end != '\n':

--- a/test.py
+++ b/test.py
@@ -1,5 +1,6 @@
-import unittest
 import collections
+import sys
+import unittest
 
 from pyprnt.util import get_terminal_size
 from pyprnt.util import border
@@ -146,10 +147,22 @@ class TestPrintBasic(unittest.TestCase):
         menu["Ice Cream"] = 100
         testee = prnt(menu, output=True, width=50)
         expect = "┌─────────┬────┐\n│kimchi   │5000│\n│Ice Cream│100 │\n└─────────┴────┘"
-        try:
-            self.assertEqual(testee, expect)
-        except:
-            pass
+        self.assertEqual(testee, expect)
+
+    def test_list_with_newline(self):
+        creation = ["Ad\nam", "Eve"]
+        testee = prnt(creation, output=True, width=50)
+        expect = "┌─┬──────┐\n│0│Ad\\nam│\n│1│Eve   │\n└─┴──────┘"
+        self.assertEqual(testee, expect)
+
+    def test_dict_with_newline(self):
+        # For python version 3.4 and below
+        menu = collections.OrderedDict()
+        menu["kimchi"] = 5000
+        menu["Ice\nCream"] = "1 €\n1.08 $"
+        testee = prnt(menu, output=True, width=50)
+        expect = "┌──────────┬───────────┐\n│kimchi    │5000       │\n│Ice\\nCream│1 €\\n1.08 $│\n└──────────┴───────────┘"
+        self.assertEqual(testee, expect)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi Kevin,

great library - thanks a lot for your work, I'm finding it very useful.

Just a couple of issues I was experiencing that I'd addressed with this PR if you're interested:
* I had \n characters in some of the entries from my dict (specifically `numpy` inserts these when representing multidimensional arrays) and this obviously breaks the nice boxes you paint around the container.  I've just changed it to literally print the string '\n' in place of the newline - that way at least I know there should have been one.
* I've changed your `list` and `dict` type checks to match any `Sequence` (except `str`) and `Mapping` as this makes your library even more general and useful.

I've put in some extra tests too.