### PR TITLE
Minor fix

### DIFF
--- a/pyprnt/util.py
+++ b/pyprnt/util.py
@@ -81,7 +81,7 @@ def create_output(obj, truncate, level, depth, width):
         else:
             value_empty = " " * (allowed_space - len(value))
 
-        if not is_sequence_container(j) and len(value) > allowed_space and not truncate:
+        if not is_sequence_container(j) and not isinstance(j, Mapping) and len(value) > allowed_space and not truncate:
             # Extra rows to print full long value
             while True:
                 if len(value) == 0:


### PR DESCRIPTION
The following piece of code results in unexpected formatting. The pull request fixes it.
```
from pyprnt import prnt
import numpy as np

garbage = 'abc'*15
d = [{'key1': garbage, 'key2':garbage, 'key3':garbage}]
prnt(d, width=20)
```
Expected output
```
┌─┬────────────────┐
│0│┌────┬─────────┐│
│ ││key1│abcabcabc││
│ ││    │abcabcabc││
│ ││    │abcabcabc││
│ ││    │abcabcabc││
│ ││    │abcabcabc││
│ ││key2│abcabcabc││
│ ││    │abcabcabc││
│ ││    │abcabcabc││
│ ││    │abcabcabc││
│ ││    │abcabcabc││
│ ││key3│abcabcabc││
│ ││    │abcabcabc││
│ ││    │abcabcabc││
│ ││    │abcabcabc││
│ ││    │abcabcabc││
│ │└────┴─────────┘│
└─┴────────────────┘
```
Actual output
```
┌─┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│0│['┌────┬─────────┐', '│key1│abcabcabc│', '│    │abcabcabc│', '│    │abcabcabc│', '│    │abcabcabc│', '│    │abcabcabc│', '│key2│abcabcabc│', '│    │abcabcabc│', '│    │abcabcabc│', '│    │abcabcabc│', '│    │abcabcabc│', '│key3│abcabcabc│', '│    │abcabcabc│', '│    │abcabcabc│', '│    │abcabcabc│', '│    │abcabcabc│']│
│ │['└────┴─────────┘']                                                                                                                                                                                                                                                                                                            │
└─┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```